### PR TITLE
remove duplicate includes for Cephei. added .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.theos/
+packages/

--- a/gameseagullprefs/GSPRootListController.m
+++ b/gameseagullprefs/GSPRootListController.m
@@ -1,7 +1,4 @@
 #include "GSPRootListController.h"
-#include <CepheiPrefs/HBAppearanceSettings.h>
-#include <Cephei/HBPreferences.h>
-#include <CepheiPrefs/HBRootListController.h>
 
 @implementation GSPRootListController
 


### PR DESCRIPTION
Removed duplicate includes for Cephei in GSPRootListController.m, they are already specified in the header file.
Added a .gitignore file